### PR TITLE
Add Maven publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,13 @@
 plugins {
     id("java-gradle-plugin")
     id("groovy")
+    id("maven-publish")
 }
 
 apply(from = "$rootDir/gradle/functional-test.gradle")
+
+group = "com.verificationgentleman.gradle"
+version = "0.1.0-SNAPSHOT"
 
 gradlePlugin {
     plugins {


### PR DESCRIPTION
This allows the plugin to be published to 'MavenLocal' and to be picked
up by other projects from there.