### PR TITLE
Fix handling of private include dirs when reconfiguring SV source

### DIFF
--- a/src/functTest/groovy/com/verificationgentleman/gradle/hdvl/SystemVerilogPluginTest.groovy
+++ b/src/functTest/groovy/com/verificationgentleman/gradle/hdvl/SystemVerilogPluginTest.groovy
@@ -364,6 +364,36 @@ class SystemVerilogPluginFunctionalTest extends Specification {
         lineWithIncdir.endsWith("src/main/sv")
     }
 
+    def "'genArgsFile' task writes private include directories to args file after re-configure of source dirs"() {
+        File sv = testProjectDir.newFolder('sv')
+        new File(sv, 'dummy.sv').createNewFile()
+
+        buildFile << """
+            sourceSets {
+                main {
+                    sv {
+                        srcDirs = ['sv']
+                    }
+                }
+            }
+        """
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withPluginClasspath()
+            .withArguments('genArgsFile')
+            .build()
+
+        then:
+        def lines = new File(testProjectDir.root, 'build/args.f').text.split("\n")
+        def lineWithIncdir = lines.find { it.contains('-incdir') }
+        lineWithIncdir != null
+        !lineWithIncdir.contains("src")
+        !lineWithIncdir.contains("main")
+        lineWithIncdir.endsWith("sv")
+    }
+
     def "'genArgsFile' task writes C files to args file"() {
         File c = testProjectDir.newFolder('src', 'main', 'c')
         new File(c, 'dummy.c').createNewFile()

--- a/src/main/java/com/verificationgentleman/gradle/hdvl/GenArgsFile.java
+++ b/src/main/java/com/verificationgentleman/gradle/hdvl/GenArgsFile.java
@@ -10,12 +10,11 @@ import javax.inject.Inject;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.Set;
 
 public class GenArgsFile extends SourceTask {
 
     private RegularFileProperty destination;
-    private Set<File> privateIncludeDirs;
+    private FileCollection privateIncludeDirs;
     private FileCollection cSourceFiles = getProject().getObjects().fileCollection();
 
     @Inject
@@ -28,12 +27,14 @@ public class GenArgsFile extends SourceTask {
         return destination;
     }
 
-    @Input
-    public Set<File> getPrivateIncludeDirs() {
+    @InputFiles
+    @SkipWhenEmpty
+    @PathSensitive(PathSensitivity.ABSOLUTE)
+    public FileCollection getPrivateIncludeDirs() {
         return privateIncludeDirs;
     }
 
-    public void setPrivateIncludeDirs(Set<File> privateIncludeDirs) {
+    public void setPrivateIncludeDirs(FileCollection privateIncludeDirs) {
         this.privateIncludeDirs = privateIncludeDirs;
     }
 

--- a/src/main/java/com/verificationgentleman/gradle/hdvl/SystemVerilogPlugin.java
+++ b/src/main/java/com/verificationgentleman/gradle/hdvl/SystemVerilogPlugin.java
@@ -54,7 +54,7 @@ public class SystemVerilogPlugin implements Plugin<Project> {
             public void execute(GenArgsFile genArgsFile) {
                 genArgsFile.setDescription("Generates an argument file for the main source code.");
                 genArgsFile.setSource(mainSourceSet.getSv());
-                genArgsFile.setPrivateIncludeDirs(mainSourceSet.getSv().getSrcDirs());
+                genArgsFile.setPrivateIncludeDirs(mainSourceSet.getSv().getSourceDirectories());
                 genArgsFile.setCSource(mainSourceSet.getC());
                 genArgsFile.getDestination().set(new File(project.getBuildDir(), "args.f"));
             }


### PR DESCRIPTION
Changes to the configuration of the SV source dirs weren't propagated
to the task. This is because it took a snapshot of the source dirs at
the time the task was configured.