### PR TITLE
Split 'svunit-build' plugin into 'Project' and 'Settings' parts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,10 @@ gradlePlugin {
             id = "com.verificationgentleman.gradle.hdvl.svunit-build"
             implementationClass = "com.verificationgentleman.gradle.hdvl.svunit.SVUnitBuildPlugin"
         }
+        create("svunit-build-injector") {
+            id = "com.verificationgentleman.gradle.hdvl.svunit-build-injector"
+            implementationClass = "com.verificationgentleman.gradle.hdvl.svunit.SVUnitBuildInjectorPlugin"
+        }
     }
 }
 

--- a/examples/simple-svunit/settings.gradle
+++ b/examples/simple-svunit/settings.gradle
@@ -4,7 +4,7 @@ sourceControl {
     gitRepository("https://github.com/tudortimi/svunit.git") {
         producesModule("org.svunit:svunit")
         plugins {
-            id "com.verificationgentleman.gradle.hdvl.svunit-build"
+            id "com.verificationgentleman.gradle.hdvl.svunit-build-injector"
         }
     }
 }

--- a/src/functTest/groovy/com/verificationgentleman/gradle/hdvl/svunit/SVUnitPluginSpec.groovy
+++ b/src/functTest/groovy/com/verificationgentleman/gradle/hdvl/svunit/SVUnitPluginSpec.groovy
@@ -47,7 +47,7 @@ class SVUnitPluginSpec extends Specification  {
                 gitRepository("https://github.com/tudortimi/svunit.git") {
                     producesModule("org.svunit:svunit")
                     plugins {
-                        id "com.verificationgentleman.gradle.hdvl.svunit-build"
+                        id "com.verificationgentleman.gradle.hdvl.svunit-build-injector"
                     }
                 }
             }

--- a/src/main/java/com/verificationgentleman/gradle/hdvl/svunit/SVUnitBuildInjectorPlugin.java
+++ b/src/main/java/com/verificationgentleman/gradle/hdvl/svunit/SVUnitBuildInjectorPlugin.java
@@ -16,13 +16,21 @@
 
 package com.verificationgentleman.gradle.hdvl.svunit;
 
+import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.initialization.Settings;
 
-public class SVUnitBuildPlugin implements Plugin<Project> {
-    public void apply(Project project) {
-        project.setGroup("org.svunit");
-        project.getConfigurations().create("default");
-        project.getArtifacts().add("default", project.getProjectDir());
+import java.util.Collections;
+
+public class SVUnitBuildInjectorPlugin implements Plugin<Settings> {
+    public void apply(Settings settings) {
+        settings.getRootProject().setName("svunit");
+        settings.getGradle().rootProject(new Action<Project>() {
+            @Override
+            public void execute(Project project) {
+                project.apply(Collections.singletonMap("plugin", SVUnitBuildPlugin.class));
+            }
+        });
     }
 }


### PR DESCRIPTION
The 'svunit-build' plugin is a 'Project' plugin that should be applied
to SVUnit. This should eventually be applied in the SVUnit repo itself,
once it has a Gradle setup.

The 'svunit-build-injector' plugin is a 'Settings' plugin. Its only task
is to inject the 'svunit-build' plugin. This will become obsolete once
we start applying 'svunit-build' in SVUnit itself.