### PR TITLE
Fix test suite to actually run tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,10 @@ dependencies {
     testImplementation("org.spockframework:spock-junit4:2.0-groovy-3.0")
 }
 
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
Spock now runs as a JUnit Platform `TestEngine`. Gradle has to be
configured to run using the newer engine.

The `spock-junit4` module wraps JUnit 4 rules (like `@TemporaryFolder`)
into Spock's extensions to assist with migration, but tests still need
to be run using the new runner.