### PR TITLE
Explicitly use Java 8 to be compatible with RHEL7

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,3 +75,10 @@ repositories {
 tasks.withType(JavaCompile::class) {
   options.compilerArgs.addAll(listOf("-Xlint:unchecked", "-Werror"))
 }
+
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}


### PR DESCRIPTION
Without this, Gradle will use the Java version it is running on. It will
upload JARs built for that Java version to the Plugin Portal.