### PR TITLE
Switch to using `jgitver` plugin to extract version from Git

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("groovy")
     id("maven-publish")
     id("com.gradle.plugin-publish") version "0.20.0"
-    id("com.palantir.git-version") version "0.13.0"
+    id("fr.brouillard.oss.gradle.jgitver") version "0.9.1"
 }
 
 pluginBundle {
@@ -15,9 +15,6 @@ pluginBundle {
 apply(from = "$rootDir/gradle/functional-test.gradle")
 
 group = "com.verificationgentleman.gradle"
-
-val gitVersion: groovy.lang.Closure<String> by extra
-version = gitVersion()
 
 gradlePlugin {
     plugins {


### PR DESCRIPTION
This plugin supports `v` as a prefix for tags, as recommended by GitHub and removes it when computing the version. The `git-version` plugin doesn't support this, because Palantir is opposed to the prefix.

Whether using the `v` prefix or not is a good idea is unclear. In any case we started with this scheme, so unless we have a good reason to deviate we should stick with it.